### PR TITLE
remove 'xserver' prefix from displayManager.sessionPackages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712608508,
-        "narHash": "sha256-vMZ5603yU0wxgyQeHJryOI+O61yrX2AHwY6LOFyV1gM=",
+        "lastModified": 1712791164,
+        "narHash": "sha256-3sbWO1mbpWsLepZGbWaMovSO7ndZeFqDSdX0hZ9nVyw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4cba8b53da471aea2ab2b0c1f30a81e7c451f4b6",
+        "rev": "1042fd8b148a9105f3c0aca3a6177fd1d9360ba5",
         "type": "github"
       },
       "original": {

--- a/nixos/cosmic/module.nix
+++ b/nixos/cosmic/module.nix
@@ -100,7 +100,7 @@ in
     security.polkit.enable = true;
 
     # session packages
-    services.xserver.displayManager.sessionPackages = with pkgs; [ cosmic-session ];
+    services.displayManager.sessionPackages = with pkgs; [ cosmic-session ];
     systemd.packages = with pkgs; [ cosmic-session ];
 
     # required for screen locker


### PR DESCRIPTION
Hello, and thank you for this repo!

Without changing anything beyond a `nix flake update`, today I got this while trying to rebuild:
```
       error: The option `services.xserver.displayManager.sessionPackages' does not exist. Definition values:
       - In `/nix/store/z0pdqcm1ywkha41a95khs6qa3bwr3yki-source/nixos/cosmic/module.nix':
           {
             _type = "if";
             condition = true;
             content = [
               <derivation cosmic-session-0-unstable-2024-04-08>
           ...
```
per [this discussion](https://github.com/NixOS/nixpkgs/pull/291913#issuecomment-2046586711) and [commit](https://github.com/NixOS/nixpkgs/commit/476b8c276e2ae4c98efd1d8d759029e170c5ca98) it appears the correct syntax is now without xserver, much as the cosmic module itself uses desktopManager/displayManager without xserver prefix.

I assume most people using this will be tracking unstable, as I am - unfortunately I'm not aware of a way to satisfy both stable and unstable users right now.