### PR TITLE
nixos/cosmic: remove 'xserver' prefix from libinput

### DIFF
--- a/nixos/cosmic-greeter/module.nix
+++ b/nixos/cosmic-greeter/module.nix
@@ -50,7 +50,7 @@ in
 
     # required features
     hardware.opengl.enable = true;
-    services.xserver.libinput.enable = true;
+    services.libinput.enable = true;
 
     # required dbus services
     services.accounts-daemon.enable = true;

--- a/nixos/cosmic/module.nix
+++ b/nixos/cosmic/module.nix
@@ -78,7 +78,7 @@ in
 
     # required features
     hardware.opengl.enable = true;
-    services.xserver.libinput.enable = true;
+    services.libinput.enable = true;
     xdg.mime.enable = true;
     xdg.icons.enable = true;
 


### PR DESCRIPTION
hello, another very useful PR to remove a nix warning :)