### PR TITLE
nixos/cosmic: add gnome-keyring

### DIFF
--- a/nixos/cosmic/module.nix
+++ b/nixos/cosmic/module.nix
@@ -92,6 +92,7 @@ in
     };
     services.gvfs.enable = lib.mkDefault true;
     networking.networkmanager.enable = lib.mkDefault true;
+    services.gnome.gnome-keyring.enable = lib.mkDefault true;
 
     # general graphical session features
     programs.dconf.enable = lib.mkDefault true;
@@ -101,9 +102,6 @@ in
     services.upower.enable = true;
     services.power-profiles-daemon.enable = lib.mkDefault (!config.hardware.system76.power-daemon.enable);
     security.polkit.enable = true;
-
-    # store secrets, passwords, keys, certificates and make them available to applications
-    services.gnome.gnome-keyring.enable = true;
 
     # session packages
     services.displayManager.sessionPackages = with pkgs; [ cosmic-session ];

--- a/nixos/cosmic/module.nix
+++ b/nixos/cosmic/module.nix
@@ -102,6 +102,9 @@ in
     services.power-profiles-daemon.enable = lib.mkDefault (!config.hardware.system76.power-daemon.enable);
     security.polkit.enable = true;
 
+    # store secrets, passwords, keys, certificates and make them available to applications
+    services.gnome.gnome-keyring.enable = true;
+
     # session packages
     services.displayManager.sessionPackages = with pkgs; [ cosmic-session ];
     systemd.packages = with pkgs; [ cosmic-session ];


### PR DESCRIPTION
This PR adds Gnome Keyring according to this [discussion](https://www.reddit.com/r/pop_os/comments/1cvd3u9/cosmic_de_which_keyring_to_use/).

This is unable to manage ssh-keys yet, see: https://github.com/NixOS/nixpkgs/pull/310978