### PR TITLE
CI: Build for AArch64

### DIFF
--- a/.github/workflows/ci_aarch64.yml
+++ b/.github/workflows/ci_aarch64.yml
@@ -1,0 +1,24 @@
+name: CI (AArch64)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-r7g.large]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@v11
+
+      - uses: cachix/cachix-action@v15
+        with:
+          name: cosmic
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - run: nix -vL build --show-trace --cores 1 --max-jobs 1 .#vm.closure

--- a/.github/workflows/cosmic.yml
+++ b/.github/workflows/cosmic.yml
@@ -47,3 +47,9 @@ jobs:
         with:
           workflow: ci.yml
           ref: refs/heads/update_cosmic_action
+
+      - uses: benc-uk/workflow-dispatch@v1
+        if: ${{ contains(fromJSON('["created", "updated"]'), steps.create-pr.outputs.pull-request-operation) }}
+        with:
+          workflow: ci_aarch64.yml
+          ref: refs/heads/update_cosmic_action

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -30,3 +30,9 @@ jobs:
         with:
           workflow: ci.yml
           ref: refs/heads/update_flake_lock_action
+
+      - uses: benc-uk/workflow-dispatch@v1
+        if: ${{ contains(fromJSON('["created", "updated"]'), steps.create-pr.outputs.pull-request-operation) }}
+        with:
+          workflow: ci_aarch64.yml
+          ref: refs/heads/update_cosmic_action

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -32,7 +32,7 @@ jobs:
           ref: refs/heads/update_flake_lock_action
 
       - uses: benc-uk/workflow-dispatch@v1
-        if: ${{ contains(fromJSON('["created", "updated"]'), steps.create-pr.outputs.pull-request-operation) }}
+        if: ${{ contains(fromJSON('["created", "updated"]'), steps.update-flake-lock.outputs.pull-request-operation) }}
         with:
           workflow: ci_aarch64.yml
-          ref: refs/heads/update_cosmic_action
+          ref: refs/heads/update_flake_lock_action


### PR DESCRIPTION
Add a workflow for building COSMIC derivations on an AArch64 runner.

The GitHub App https://github.com/apps/drakon64-github-actions-runner-aws has to be added to the repository before running the workflow so that the webhook that creates the runner instance is enabled.

The specs of the instance are as follows:
- CPU: 2 vCPU's (AWS Graviton3)
  - Given that build parallelism is disabled in the existing workflows I assumed 4 vCPU's (the same as a GitHub-hosted runner) would be redundant, but I can make this change if need be
- Memory: 16 GiB (same as a GitHub-hosted runner)
- Storage: 14 GB SSD (same as a GitHub-hosted runner)

We could potentially increase build parallelism if we increase the size of the runner instance, I'm happy to have that discussion.

I'm willing to host this until COSMIC is available in a stable NixOS release, at which point I'd assume Hydra would have taken over the duties anyway.

Closes https://github.com/lilyinstarlight/nixos-cosmic/issues/104.