### PR TITLE
AArch64 CI: Increase disk size to 30GB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
   build_aarch64_linux:
     name: Build - aarch64-linux
-    runs-on: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-r7g.large]
+    runs-on: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-r7g.large, EBS-30GB]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The disk size on the AArch64 build runner was temporarily increased to 30GB for all repositories. As the disk size can now be configured as part of a workflow, this PR explicitly sets the disk size to the required 30GB so that builds will be unaffected when I eventually return the default back to its original 14GB.