### PR TITLE
ci: use build matrix for building and caching stable packages as well

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,8 +6,10 @@ pull_request_rules:
         - author=github-actions[bot]
       - label=dependencies
 
-      - check-success=Build - x86_64-linux
-      - check-success=Build - aarch64-linux
+      - check-success=Build - x86_64-linux - vm.closure
+      - check-success=Build - aarch64-linux - vm.closure
+      - check-success=Build - x86_64-linux - vm-stable.closure
+      - check-success=Build - aarch64-linux - vm-stable.closure
     actions:
       merge:
         method: squash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,22 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_x86_64_linux:
-    name: Build - x86_64-linux
-    runs-on: [linux, X64, drakon64/github-actions-runner-aws, EC2-r7i.large, EBS-30GB]
+  build:
+    strategy:
+      matrix:
+        architecture:
+          - system: x86_64-linux
+            runner: [linux, X64, drakon64/github-actions-runner-aws, EC2-r7i.large, EBS-30GB]
+          - system: aarch64-linux
+            runner: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-r7g.large, EBS-30GB]
+        attribute:
+          - vm.closure
+          - vm-stable.closure
+
+    name: Build - ${{ matrix.architecture.system }} - ${{ matrix.attribute }}
+    runs-on: ${{ matrix.architecture.runner }}
     timeout-minutes: 1440
+
     steps:
       - uses: actions/checkout@v4
 
@@ -22,20 +34,8 @@ jobs:
           name: cosmic
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - run: nix -vL build --show-trace --cores 1 --max-jobs 1 .#vm.closure
-
-  build_aarch64_linux:
-    name: Build - aarch64-linux
-    runs-on: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-r7g.large, EBS-30GB]
-    timeout-minutes: 1440
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: DeterminateSystems/nix-installer-action@v11
-
-      - uses: cachix/cachix-action@v15
-        with:
-          name: cosmic
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-
-      - run: nix -vL build --show-trace --cores 1 --max-jobs 1 .#vm.closure
+      - env:
+          SYSTEM: ${{ matrix.architecture.system }}
+          ATTRIBUTE: ${{ matrix.attribute }}
+        run: |
+          nix -vL build --show-trace --cores 1 --max-jobs 1 --system "$SYSTEM" ".#$ATTRIBUTE"

--- a/flake.lock
+++ b/flake.lock
@@ -32,10 +32,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1717090882,
+        "narHash": "sha256-Up5tvtY9YlVEyVn9hfZcxFQi5qVhQ5hdVNGPQOUchNw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d24e7fdcfaecdca496ddd426cae98c9e2d12dfe8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-stable": "nixpkgs-stable"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,15 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.05";
+
     flake-compat = {
       url = "github:nix-community/flake-compat";
       flake = false;
     };
   };
 
-  outputs = { self, nixpkgs, ... }: let
+  outputs = { self, nixpkgs, nixpkgs-stable, ... }: let
     forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
   in {
     lib = {
@@ -51,7 +53,7 @@
         '';
       };
 
-      vm = let
+      vm = nixpkgs.lib.makeOverridable ({ nixpkgs }: let
         nixosConfig = nixpkgs.lib.nixosSystem {
           modules = [
             ({ lib, pkgs, modulesPath, ... }: {
@@ -114,7 +116,9 @@
             })
           ];
         };
-      in nixosConfig.config.system.build.vm // { closure = nixosConfig.config.system.build.toplevel; inherit (nixosConfig) config pkgs; };
+      in nixosConfig.config.system.build.vm // { closure = nixosConfig.config.system.build.toplevel; inherit (nixosConfig) config pkgs; }) { inherit nixpkgs; };
+
+      vm-stable = self.legacyPackages.${system}.vm.override { nixpkgs = nixpkgs-stable; };
     });
   };
 }


### PR DESCRIPTION
Builds and caches for nixos-24.05 as well as nixos-unstable

@drakon64 Is doing two builds per architecture per CI run going to be okay for the AWS builders? (especially in terms of cost)

Fixes #139