### PR TITLE
Add `udev` and `libinput` to `cosmic-greeter` build inputs

### DIFF
--- a/pkgs/cosmic-greeter/package.nix
+++ b/pkgs/cosmic-greeter/package.nix
@@ -5,6 +5,7 @@
 , cmake
 , coreutils
 , just
+, libinput
 , linux-pam
 , rust
 , stdenv
@@ -44,7 +45,7 @@ rustPlatform.buildRustPackage {
   };
 
   nativeBuildInputs = [ libcosmicAppHook rustPlatform.bindgenHook cmake just ];
-  buildInputs = [ linux-pam udev ];
+  buildInputs = [ libinput linux-pam udev ];
 
   cargoBuildFlags = [ "--all" ];
 

--- a/pkgs/cosmic-greeter/package.nix
+++ b/pkgs/cosmic-greeter/package.nix
@@ -8,7 +8,7 @@
 , linux-pam
 , rust
 , stdenv
-, systemd
+, udev
 }:
 
 rustPlatform.buildRustPackage {
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage {
   };
 
   nativeBuildInputs = [ libcosmicAppHook rustPlatform.bindgenHook cmake just ];
-  buildInputs = [ linux-pam systemd ];
+  buildInputs = [ linux-pam udev ];
 
   cargoBuildFlags = [ "--all" ];
 

--- a/pkgs/cosmic-greeter/package.nix
+++ b/pkgs/cosmic-greeter/package.nix
@@ -8,6 +8,7 @@
 , linux-pam
 , rust
 , stdenv
+, systemd
 }:
 
 rustPlatform.buildRustPackage {
@@ -43,7 +44,7 @@ rustPlatform.buildRustPackage {
   };
 
   nativeBuildInputs = [ libcosmicAppHook rustPlatform.bindgenHook cmake just ];
-  buildInputs = [ linux-pam ];
+  buildInputs = [ linux-pam systemd ];
 
   cargoBuildFlags = [ "--all" ];
 


### PR DESCRIPTION
Current `cosmic-greeter` builds are failing due to a dependency on `libudev` and `libinput`. This PR resolves the dependency.