### PR TITLE
CI: Increase cores to 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
           SYSTEM: ${{ matrix.architecture.system }}
           ATTRIBUTE: ${{ matrix.attribute }}
         run: |
-          nix -vL build --show-trace --cores 1 --max-jobs 1 --system "$SYSTEM" ".#$ATTRIBUTE"
+          nix -vL build --show-trace --cores 2 --max-jobs 1 --system "$SYSTEM" ".#$ATTRIBUTE"


### PR DESCRIPTION
Increase the cores available to Nix builds to 2.

Compared to the current setting of 1, this can potentially reduce a 6.5 hour build to a 4.5 hour build, see https://github.com/drakon64/nixos-cosmic/actions/runs/9487855050 where all caches were disabled. Interestingly, ARM builds are also faster than x86 as a result.

This does lead to swap being used but I do not believe we are at risk of resource exhaustion.
<img width="1440" alt="image" src="https://github.com/lilyinstarlight/nixos-cosmic/assets/6444703/0d2a2ae0-5b01-4fea-8103-eb7907589917">
