### PR TITLE
readme: link tracking issue and matrix room

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,8 @@
 # NixOS COSMIC
 
-Nix package set and NixOS module for using COSMIC from NixOS. This is a temporary repository for testing COSMIC on NixOS as it is developed. When COSMIC gets more stable and it is fully working on NixOS, these packages and module are intended to be merged upstream into nixpkgs.
+Nix package set and NixOS module for using COSMIC from NixOS. This is a temporary repository for testing COSMIC on NixOS as it is developed. When COSMIC gets more stable and it is fully working on NixOS, these packages and module are intended to be merged upstream into nixpkgs(track progress [here](https://github.com/NixOS/nixpkgs/issues/259641).
 
+Dedicated development matrix room: https://matrix.to/#/#cosmic:nixos.org
 
 ## Usage
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # NixOS COSMIC
 
-Nix package set and NixOS module for using COSMIC from NixOS. This is a temporary repository for testing COSMIC on NixOS as it is developed. When COSMIC gets more stable and it is fully working on NixOS, these packages and module are intended to be merged upstream into nixpkgs([issue to be updated when upstreaming](https://github.com/NixOS/nixpkgs/issues/259641).
+Nix package set and NixOS module for using COSMIC from NixOS. This is a temporary repository for testing COSMIC on NixOS as it is developed. When COSMIC gets more stable and it is fully working on NixOS, these packages and module are intended to be merged upstream into nixpkgs ([issue to be updated when upstreaming](https://github.com/NixOS/nixpkgs/issues/259641)).
 
 Dedicated development matrix room: <https://matrix.to/#/#cosmic:nixos.org>
 

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # NixOS COSMIC
 
-Nix package set and NixOS module for using COSMIC from NixOS. This is a temporary repository for testing COSMIC on NixOS as it is developed. When COSMIC gets more stable and it is fully working on NixOS, these packages and module are intended to be merged upstream into nixpkgs(track progress [here](https://github.com/NixOS/nixpkgs/issues/259641).
+Nix package set and NixOS module for using COSMIC from NixOS. This is a temporary repository for testing COSMIC on NixOS as it is developed. When COSMIC gets more stable and it is fully working on NixOS, these packages and module are intended to be merged upstream into nixpkgs([issue to be updated when upstreaming](https://github.com/NixOS/nixpkgs/issues/259641).
 
-Dedicated development matrix room: https://matrix.to/#/#cosmic:nixos.org
+Dedicated development matrix room: <https://matrix.to/#/#cosmic:nixos.org>
 
 ## Usage
 


### PR DESCRIPTION
I wanted to try Cosmic and ended up here after googling my way to the tracking issue. 

Thanks for taking the time to make this flake!

I thought this readme could lead back to the tracking issue for people to easily find what is going on and test Cosmic on NixOS. 

Same for the matrix room.