### PR TITLE
CI: Remove custom timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
 
     name: Build - ${{ matrix.architecture.system }} - ${{ matrix.attribute }}
     runs-on: ${{ matrix.architecture.runner }}
-    timeout-minutes: 1440
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Remove the custom timeout for CI builds and return to the default. There's two reasons for doing this:

1. https://github.com/lilyinstarlight/nixos-cosmic/pull/165 made a custom timeout redundant
2. Builds are currently being help up because of an issue with starting the ARM runners. When an ARM runner is requested, the previous job that was being held up ends up running on the new runner and then the new job is then held up. I'm working on fixing the source of this issue.

This will likely cause the next CI build to fail due to a timeout (because of point 2) but the build after should return to normal.