### PR TITLE
Expose nixos modules and overlays through flake-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,21 +1,15 @@
-{ system ? builtins.currentSystem, ... }:
-
-let
-  self = (import (
-      let
-        lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-      in fetchTarball {
-        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${lock.nodes.${lock.root}.inputs.flake-compat}.locked.rev}.tar.gz";
-        sha256 = lock.nodes.flake-compat.locked.narHash;
-      }
-    )
-    {
-      # hack to skip fetchGit when evaluating impurely and get original paths
-      src = {
-        outPath = ./.;
-      };
+(import (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${lock.nodes.${lock.root}.inputs.flake-compat}.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
     }
-  ).defaultNix;
-in
-
-self.packages.${system}
+  )
+  {
+    # hack to skip fetchGit when evaluating impurely and get original paths
+    src = {
+      outPath = ./.;
+    };
+  }
+).defaultNix


### PR DESCRIPTION
:wave: hello

I've been daily driving cosmic on nixos for about a month now.

In order to do that I had to clone the project and do this small adjustment since I don't use flakes, but rather npins, as pinning mechanism.

This might break other folks using `default.nix` but would allow non-flake users to have all the other options, not only the packages.

Hope that makes sense and help more people.