### PR TITLE
Rename `hardware.opengl.enable` to `hardware.graphics.enable`

### DIFF
--- a/nixos/cosmic-greeter/module.nix
+++ b/nixos/cosmic-greeter/module.nix
@@ -51,7 +51,7 @@ in
     users.groups.cosmic-greeter = { };
 
     # required features
-    hardware.opengl.enable = true;
+    hardware.graphics.enable = true;
     services.libinput.enable = true;
 
     # required dbus services

--- a/nixos/cosmic/module.nix
+++ b/nixos/cosmic/module.nix
@@ -77,7 +77,7 @@ in
     ]) config.environment.cosmic.excludePackages;
 
     # required features
-    hardware.opengl.enable = true;
+    hardware.graphics.enable = true;
     services.libinput.enable = true;
     xdg.mime.enable = true;
     xdg.icons.enable = true;


### PR DESCRIPTION
`hardware.opengl.enable` has been deprecated and replaced with `hardware.graphics.enable`.

Draft until I confirm that this doesn't break NixOS 24.05 builds.