### PR TITLE
Rename hardware.opengl to hardware.graphics

### DIFF
--- a/nixos/cosmic/module.nix
+++ b/nixos/cosmic/module.nix
@@ -77,7 +77,7 @@ in
     ]) config.environment.cosmic.excludePackages;
 
     # required features
-    hardware.opengl.enable = true;
+    hardware.graphics.enable = true;
     services.libinput.enable = true;
     xdg.mime.enable = true;
     xdg.icons.enable = true;


### PR DESCRIPTION
When I ran `nixos-rebuild`, I got this warning: `trace: warning: The option `hardware.opengl.enable' defined in `/nix/store/wr1fdz9blr31ighgygn0mnryvxxk7i8a-source/nixos/cosmic/module.nix' has been renamed to `hardware.graphics.enable'.`. So I updated the file that was causing the warning.