### PR TITLE
rename gnome.adwaita-icon-theme

### DIFF
--- a/nixos/cosmic/module.nix
+++ b/nixos/cosmic/module.nix
@@ -51,7 +51,7 @@ in
       cosmic-settings-daemon
       cosmic-term
       cosmic-workspaces-epoch
-      gnome.adwaita-icon-theme
+      adwaita-icon-theme
       hicolor-icon-theme
       pop-icon-theme
       pop-launcher


### PR DESCRIPTION
In nixos-unstable, adwait-icon-theme has been moved to the top-level.

```console
trace: warning: The ‘gnome.adwaita-icon-theme’ was moved to top-level. Please use ‘pkgs.adwaita-icon-theme’ directly.
```