### PR TITLE
Add `libinput` to `cosmic-settings-daemon` build inputs, remove `config.ron` from `cosmic-comp`, and disable NixOS Stable builds

### DIFF
--- a/nixos/cosmic/module.nix
+++ b/nixos/cosmic/module.nix
@@ -28,7 +28,6 @@ in
     ''];
 
     # environment packages
-    environment.etc."cosmic-comp/config.ron".source = lib.mkDefault "${pkgs.cosmic-comp}/etc/cosmic-comp/config.ron";
     environment.pathsToLink = [ "/share/cosmic" ];
     environment.systemPackages = utils.removePackagesByName (with pkgs; [
       adwaita-icon-theme

--- a/pkgs/cosmic-comp/package.nix
+++ b/pkgs/cosmic-comp/package.nix
@@ -61,7 +61,6 @@ rustPlatform.buildRustPackage {
 
   postInstall = ''
     mkdir -p $out/etc/cosmic-comp
-    cp config.ron $out/etc/cosmic-comp/config.ron
   '' + lib.optionalString useXWayland ''
     libcosmicAppWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ xwayland ]})
   '';

--- a/pkgs/cosmic-settings-daemon/package.nix
+++ b/pkgs/cosmic-settings-daemon/package.nix
@@ -4,6 +4,7 @@
 , geoclue2-with-demo-agent
 , libinput
 , pkg-config
+, libinput
 , udev
 }:
 


### PR DESCRIPTION
_Re-raising against the correct branch._

Hopefully fixes the current build error as seen at https://github.com/lilyinstarlight/nixos-cosmic/actions/runs/9786692783/job/27022004024.

Also removed NixOS 24.05 builds from Mergify requirements as COSMIC can no longer be built with the available Rust toolchain.

https://github.com/lilyinstarlight/nixos-cosmic/pull/199 should build successfully if this is merged and https://github.com/NixOS/nixpkgs/pull/320250 reaches Unstable.

Also, as of https://github.com/pop-os/cosmic-comp/commit/553c49b42b5941002b3dd1e7b3fddaf58760dcd1 the `config.ron` file no longer exists so I removed it from the Flake.