### PR TITLE
CI: Upgrade runner instance types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         architecture:
           - system: x86_64-linux
-            runner: [linux, X64, drakon64/github-actions-runner-aws, EC2-r7i.large, EBS-30GB]
+            runner: [linux, X64, drakon64/github-actions-runner-aws, EC2-r7a.large, EBS-30GB]
           - system: aarch64-linux
             runner: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-r8g.large, EBS-30GB]
         attribute:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           - system: x86_64-linux
             runner: [linux, X64, drakon64/github-actions-runner-aws, EC2-r7i.large, EBS-30GB]
           - system: aarch64-linux
-            runner: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-r7g.large, EBS-30GB]
+            runner: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-r8g.large, EBS-30GB]
         attribute:
           - vm.closure
           #- vm-stable.closure


### PR DESCRIPTION
I've moved the AWS instances from London to Frankfurt which gives us a few more instance options.

In summary:

- x86_64: Intel Xeon Scalable 8488C -> AMD EPYC 9R14
  - Higher clock speed
  - No SMT
  - vCPU count remains the same
- AArch64: AWS Graviton3 -> AWS Graviton4
  - Generational upgrade


Phoronix has some benchmarks comparing the old to the new but in a larger vCPU/memory configuration https://www.phoronix.com/review/aws-graviton4-benchmarks/4