### PR TITLE
Build COSMIC with a Rust overlay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
           SYSTEM: ${{ matrix.architecture.system }}
           ATTRIBUTE: ${{ matrix.attribute }}
         run: |
-          nix -vL build --show-trace --cores 2 --max-jobs 1 --system "$SYSTEM" ".#$ATTRIBUTE"
+          nix -vL build --show-trace --cores 2 --max-jobs 1 --system "$SYSTEM" --impure ".#$ATTRIBUTE"

--- a/.github/workflows/cosmic.yml
+++ b/.github/workflows/cosmic.yml
@@ -27,7 +27,7 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - run: nix -vL run --show-trace .#update
+      - run: nix -vL run --show-trace --impure .#update
 
       - id: create-pr
         uses: peter-evans/create-pull-request@v6

--- a/flake.nix
+++ b/flake.nix
@@ -4,13 +4,18 @@
 
     nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.05";
 
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     flake-compat = {
       url = "github:nix-community/flake-compat";
       flake = false;
     };
   };
 
-  outputs = { self, nixpkgs, nixpkgs-stable, ... }: let
+  outputs = { self, nixpkgs, nixpkgs-stable, rust-overlay, ... }: let
     forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
   in {
     lib = {

--- a/pkgs/cosmic-settings/package.nix
+++ b/pkgs/cosmic-settings/package.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, rustPlatform
+, makeRustPlatform
 , libcosmicAppHook
 , cmake
 , cosmic-randr
@@ -17,6 +17,22 @@
 
 let
   libcosmicAppHook' = (libcosmicAppHook.__spliced.buildHost or libcosmicAppHook).override { includeSettings = false; };
+
+  rust-overlay = import <nixpkgs> {
+    overlays = [
+      (import (fetchFromGitHub {
+        owner = "oxalica";
+        repo = "rust-overlay";
+        rev = "8b81b8ed00b20fd57b24adcb390bd96ea81ecd90";
+        hash = "sha256-bW2ClCWzGCytPbUnqZwU8P1YsLW07uEs80EfHEctc0Q=";
+      }))
+    ];
+  };
+
+  rustPlatform = makeRustPlatform {
+    cargo = rust-overlay.rust-bin.stable."1.80.0".default;
+    rustc = rust-overlay.rust-bin.stable."1.80.0".default;
+  };
 in
 
 rustPlatform.buildRustPackage {

--- a/pkgs/xdg-desktop-portal-cosmic/package.nix
+++ b/pkgs/xdg-desktop-portal-cosmic/package.nix
@@ -1,5 +1,5 @@
 { lib
-, rustPlatform
+, makeRustPlatform
 , fetchFromGitHub
 , libcosmicAppHook
 , pkg-config
@@ -7,6 +7,24 @@
 , pipewire
 , gst_all_1
 }:
+
+let
+  rust-overlay = import <nixpkgs> {
+    overlays = [
+      (import (fetchFromGitHub {
+        owner = "oxalica";
+        repo = "rust-overlay";
+        rev = "8b81b8ed00b20fd57b24adcb390bd96ea81ecd90";
+        hash = "sha256-bW2ClCWzGCytPbUnqZwU8P1YsLW07uEs80EfHEctc0Q=";
+      }))
+    ];
+  };
+
+  rustPlatform = makeRustPlatform {
+    cargo = rust-overlay.rust-bin.stable."1.80.0".default;
+    rustc = rust-overlay.rust-bin.stable."1.80.0".default;
+  };
+in
 
 rustPlatform.buildRustPackage rec {
   pname = "xdg-desktop-portal-cosmic";


### PR DESCRIPTION
Some COSMIC packages now require Rust 1.80.0 to compile. This PR adds a Rust overlay to allow these builds to pass without having to wait for Nixpkgs.

Draft, as I don't know how to get the overlay to work with Flakes. I know we add `rust-overlay` as Flake input but I've never been able to then get the workflows to work and to have COSMIC be installable.