### PR TITLE
CI: increase core count, memory, and swap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         architecture:
           - system: x86_64-linux
-            runner: [linux, X64, drakon64/github-actions-runner-aws, EC2-r7a.large, EBS-30GB]
+            runner: [linux, X64, drakon64/github-actions-runner-aws, EC2-r7a.2xlarge, EBS-30GB, EBS-64GB-Swap]
           - system: aarch64-linux
-            runner: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-r8g.large, EBS-30GB]
+            runner: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-r8g.2xlarge, EBS-30GB, EBS-64GB-Swap]
         attribute:
           - vm.closure
           - vm-stable.closure
@@ -37,4 +37,4 @@ jobs:
           SYSTEM: ${{ matrix.architecture.system }}
           ATTRIBUTE: ${{ matrix.attribute }}
         run: |
-          nix -vL build --show-trace --cores 2 --max-jobs 1 --system "$SYSTEM" ".#$ATTRIBUTE"
+          nix -vL build --show-trace --cores 8 --max-jobs 1 --system "$SYSTEM" ".#$ATTRIBUTE"


### PR DESCRIPTION
I've been running some tests to reduce build times. For whatever reason the Rust compiler isn't able to fully utilise 16 cores, so it seems like 8 cores is the next best option that doesn't lead to underutilisation.

In testing, this reduced the x86_64 Unstable build time to {{ time }} (my last test was with 16 cores, haven't had the time to test with 8 cores yet).

Draft as the `EBS-Swap` option is currently not merged into the main CI Lambda function, but I think it would still be good to get comments on this.