### PR TITLE
nixos/cosmic: Add playerctl as a dependency

### DIFF
--- a/nixos/cosmic/module.nix
+++ b/nixos/cosmic/module.nix
@@ -59,6 +59,7 @@ in
       cosmic-term
       cosmic-workspaces-epoch
       hicolor-icon-theme
+      playerctl
       pop-icon-theme
       pop-launcher
     ] ++ lib.optionals config.services.flatpak.enable [


### PR DESCRIPTION
Cosmic uses playerctl to implement the XF86 Media keys, see pop-os/cosmic-settings-daemon#41