### PR TITLE
Add `pipewire` to `cosmic-settings` build inputs

### DIFF
--- a/pkgs/cosmic-settings/package.nix
+++ b/pkgs/cosmic-settings/package.nix
@@ -10,6 +10,7 @@
 , freetype
 , just
 , libinput
+, pipewire
 , pkg-config
 , udev
 , util-linux
@@ -57,7 +58,7 @@ rustPlatform.buildRustPackage {
   };
 
   nativeBuildInputs = [ libcosmicAppHook' cmake just pkg-config util-linux ];
-  buildInputs = [ expat fontconfig freetype libinput udev ];
+  buildInputs = [ expat fontconfig freetype libinput pipewire udev ];
 
   dontUseJustBuild = true;
 


### PR DESCRIPTION
Spotted this when trying to diagnose an `icu_datetime` build issue (which I couldn't replicate).

This is needed for the COSMIC pipeline to run. There's still an issue where pkg-config isn't finding `libclang`, not sure how to fix that one.