### PR TITLE
CI: Reduce memory for x86_64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         architecture:
           - system: x86_64-linux
-            runner: [linux, X64, drakon64/github-actions-runner-aws, EC2-r7a.2xlarge, EBS-30GB, EBS-64GB-Swap]
+            runner: [linux, X64, drakon64/github-actions-runner-aws, EC2-m7a.2xlarge, EBS-30GB, EBS-32GB-Swap]
           - system: aarch64-linux
-            runner: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-r8g.2xlarge, EBS-30GB, EBS-64GB-Swap]
+            runner: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-r8g.2xlarge, EBS-30GB, EBS-32GB-Swap]
         attribute:
           - vm.closure
           - vm-stable.closure


### PR DESCRIPTION
As part of https://github.com/lilyinstarlight/nixos-cosmic/pull/246 the CI instances were given significantly more cores and memory. It turns out that the memory upgrades weren't necessary, so this PR reduces the memory allocated to the x86_64 instance while keeping the core count the same.

We currently cannot do this for AArch64 without also downgrading the CPU generation. Given that AArch64 builds currently lag behind x86_64, I don't want to make this worse.