### PR TITLE
Remove workaround for cosmic-bg Cargo dependency

### DIFF
--- a/pkgs/cosmic-bg/package.nix
+++ b/pkgs/cosmic-bg/package.nix
@@ -10,12 +10,12 @@
 
 rustPlatform.buildRustPackage {
   pname = "cosmic-bg";
-  version = "1.0.0-alpha.1-unstable-2024-08-27";
+  version = "1.0.0-alpha.1-unstable-2024-08-31";
 
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-bg";
-    rev = "e5e91d93fb7cd7e917922eceaddd4d412df46f93";
+    rev = "b327d3720cbd4aad5c308a005ba89e42ad354533";
     hash = "sha256-3hhS4/+5wj5pjVKdS+BPy8Q7UUFaMKiGANfDIRBm+Dc=";
   };
 

--- a/pkgs/cosmic-bg/package.nix
+++ b/pkgs/cosmic-bg/package.nix
@@ -17,11 +17,6 @@ rustPlatform.buildRustPackage {
     repo = "cosmic-bg";
     rev = "e5e91d93fb7cd7e917922eceaddd4d412df46f93";
     hash = "sha256-3hhS4/+5wj5pjVKdS+BPy8Q7UUFaMKiGANfDIRBm+Dc=";
-    # TODO: remove when <https://github.com/pop-os/cosmic-bg/commit/ed9ea6cc15638b08c848fda042ec2df3ff69865f#r145966372> is addressed
-    postFetch = ''
-      substituteInPlace $out/Cargo.toml --replace-fail 'libcosmic?branch=master' '/libcosmic'
-      substituteInPlace $out/Cargo.lock --replace-fail 'libcosmic?branch=master?rev=' '/libcosmic?rev='
-    '';
   };
 
   cargoLock = {


### PR DESCRIPTION
Currently the COSMIC workflow is failing because https://github.com/pop-os/cosmic-bg/commit/ed9ea6cc15638b08c848fda042ec2df3ff69865f#r145966372 has been addressed and the `postFetch` stage of pulling the source code for `cosmic-bg` fails because the fix is no longer needed and no longer works.

This change bumps `cosmic-bg` to a version where this fix is no longer required and removes the fix.