### PR TITLE
add env variables for xkb-data paths

### DIFF
--- a/pkgs/cosmic-greeter/package.nix
+++ b/pkgs/cosmic-greeter/package.nix
@@ -10,6 +10,7 @@
 , stdenv
 , udev
 , nix-update-script
+, xkeyboard_config
 }:
 
 rustPlatform.buildRustPackage {
@@ -65,6 +66,11 @@ rustPlatform.buildRustPackage {
 
   postPatch = ''
     substituteInPlace src/greeter.rs --replace-fail '/usr/bin/env' '${lib.getExe' coreutils "env"}'
+  '';
+
+  postInstall = ''
+    libcosmicAppWrapperArgs+=(--set X11_BASE_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/base.xml)
+    libcosmicAppWrapperArgs+=(--set X11_EXTRA_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/base.extras.xml)
   '';
 
   passthru.updateScript = nix-update-script {

--- a/pkgs/cosmic-settings/package.nix
+++ b/pkgs/cosmic-settings/package.nix
@@ -16,6 +16,7 @@
 , udev
 , util-linux
 , nix-update-script
+, xkeyboard_config
 }:
 
 let
@@ -76,6 +77,8 @@ rustPlatform.buildRustPackage {
 
   postInstall = ''
     libcosmicAppWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ cosmic-randr ]})
+    libcosmicAppWrapperArgs+=(--set X11_BASE_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/base.xml)
+    libcosmicAppWrapperArgs+=(--set X11_EXTRA_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/base.extras.xml)
   '';
 
   passthru.updateScript = nix-update-script {


### PR DESCRIPTION
The xkb-data crate used hard-coded paths for locating the xkb rule XML files. Since version 0.2.1 there is a way to overwrite these hard-coded paths using the X11_BASE_RULES_XML and X11_EXTRA_RULES_XML environment variables. This patch adds these variables to the wrappers of cosmic-settings and comsic-greeter.

This should fix issue #74 for cosmic-settings. cosmic-greeter should start working as soon as the cosmic devs bump its version of the xkb-data crate.