### PR TITLE
CI: Reduce memory for AArch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           - system: x86_64-linux
             runner: [linux, X64, drakon64/github-actions-runner-aws, EC2-m7a.2xlarge, EBS-30GB, EBS-32GB-Swap]
           - system: aarch64-linux
-            runner: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-r8g.2xlarge, EBS-30GB, EBS-32GB-Swap]
+            runner: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-m8g.2xlarge, EBS-30GB, EBS-32GB-Swap]
         attribute:
           - vm.closure
           - vm-stable.closure


### PR DESCRIPTION
This brings the AArch64 CI instance in line with the x86_64 instance. The CPU is unchanged, there's just less memory now (which wasn't being used anyway).

Finishes the work started in https://github.com/lilyinstarlight/nixos-cosmic/pull/266.