### PR TITLE
nixos/cosmic: add warning if cosmic-files is excluded

### DIFF
--- a/nixos/cosmic/module.nix
+++ b/nixos/cosmic/module.nix
@@ -162,8 +162,12 @@ in
     # required for screen locker
     security.pam.services.cosmic-greeter = { };
 
-    warnings = if (builtins.elem pkgs.cosmic-files config.environment.cosmic.excludePackages)
-      then [ ''The COSMIC Session may fail to initialise without the cosmic-files package (excluded).'' ]
-      else [];
+    warnings = lib.optional (lib.elem pkgs.cosmic-files config.environment.cosmic.excludePackages -> !(lib.elem pkgs.cosmic-session config.environment.cosmic.excludePackages)) ''
+      The COSMIC session may fail to initialise with the `cosmic-files` package excluded via `config.environment.cosmic.excludePackages`.
+      
+      Please do one of the following:
+        1. Remove `cosmic-files` from `config.environment.cosmic.excludePackages`.
+        2. Add `cosmic-session` (in addition to `cosmic-files`) to `config.environment.cosmic.excludePackages` and ensure whatever session starter/manager you are using is appropriately set up.
+    '';
   };
 }

--- a/nixos/cosmic/module.nix
+++ b/nixos/cosmic/module.nix
@@ -161,5 +161,9 @@ in
 
     # required for screen locker
     security.pam.services.cosmic-greeter = { };
+
+    warnings = if (builtins.elem pkgs.cosmic-files config.environment.cosmic.excludePackages)
+      then [ ''The COSMIC Session may fail to initialise without the cosmic-files package (excluded).'' ]
+      else [];
   };
 }


### PR DESCRIPTION
per [this issue/comment](https://github.com/pop-os/cosmic-epoch/issues/1069#issuecomment-2397624433), COSMIC Session requires the cosmic-files package to provide desktop context menus, and will refuse to launch without it.

this PR detects if cosmic-files is in the excludedPackages list and informs the user of potential consequences.