### PR TITLE
Temporarily replace the existing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         architecture:
           - system: x86_64-linux
-            runner: [linux, X64, drakon64/github-actions-runner-aws, EC2-m7a.2xlarge, EBS-30GB, EBS-32GB-Swap]
+            runner: [self-hosted, linux, x64]
           - system: aarch64-linux
-            runner: [linux, ARM64, drakon64/github-actions-runner-aws, EC2-m8g.2xlarge, EBS-30GB, EBS-32GB-Swap]
+            runner: [self-hosted, linux, ARM64]
         attribute:
           - vm.closure
           - vm-stable.closure
@@ -37,4 +37,4 @@ jobs:
           SYSTEM: ${{ matrix.architecture.system }}
           ATTRIBUTE: ${{ matrix.attribute }}
         run: |
-          nix -vL build --show-trace --cores 8 --max-jobs 1 --system "$SYSTEM" ".#$ATTRIBUTE"
+          nix -vL build --show-trace --cores 1 --max-jobs 1 --system "$SYSTEM" ".#$ATTRIBUTE"


### PR DESCRIPTION
Temporarily replace the existing CI solution with two long-running VM's (one for x86-64 and one for AArch64). These VM's have less resources allocated to them than the usual CI, so Nix has to be told to run on less cores (to be honest I'm not sure throwing 8 CPU's at Nix was efficient given how the Cargo wrapper works).