### PR TITLE
Temporarily increase build time limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
 
     name: Build - ${{ matrix.architecture.system }} - ${{ matrix.attribute }}
     runs-on: ${{ matrix.architecture.runner }}
+    timeout-minutes: 720 # 12 hours
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Temporarily increase build time limit to 12 hours until we have faster build runners