### PR TITLE
Set `min-free` to prevent CI disk filling up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: DeterminateSystems/nix-installer-action@v16
+        with:
+          extra-conf: |
+            min-free = 1000000000
 
       - uses: cachix/cachix-action@v15
         with:


### PR DESCRIPTION
Setting this will force Nix to collect garbage when the partition where `/nix` is stored reaches less than 1 GB of free space.