### PR TITLE
CI: Use ephemeral self-hosted runners (again)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,24 +13,20 @@ jobs:
       matrix:
         architecture:
           - system: x86_64-linux
-            runner: [self-hosted, linux, x64]
+            runner: [linux, x64, ktisis, ktisis-n4-highmem-4, ktisis-30GB]
           - system: aarch64-linux
-            runner: [self-hosted, linux, ARM64]
+            runner: [linux, ARM64, ktisis, ktisis-c4a-highmem-4, ktisis-30GB]
         attribute:
           - vm.closure
           - vm-stable.closure
 
     name: Build - ${{ matrix.architecture.system }} - ${{ matrix.attribute }}
     runs-on: ${{ matrix.architecture.runner }}
-    timeout-minutes: 720 # 12 hours
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: DeterminateSystems/nix-installer-action@v16
-        with:
-          extra-conf: |
-            min-free = 1000000000
 
       - uses: cachix/cachix-action@v15
         with:
@@ -41,4 +37,4 @@ jobs:
           SYSTEM: ${{ matrix.architecture.system }}
           ATTRIBUTE: ${{ matrix.attribute }}
         run: |
-          nix -vL build --show-trace --cores 1 --max-jobs 1 --system "$SYSTEM" ".#$ATTRIBUTE"
+          nix -vL build --show-trace --cores 4 --max-jobs 1 --system "$SYSTEM" ".#$ATTRIBUTE"


### PR DESCRIPTION
Return to using ephemeral self-hosted runners rather than leaving two runners on 24/7.

As these runners are only on while a build is running, we can make them larger. My account currently has a quota for CPU cores so I've had to allocate 4 cores rather than the desired 8, but I'm hoping to get this resolved.

The x86 VM is an Intel Sapphire Rapids, and the AArch64 VM is a Google Axion. Both have 4 cores and 32 GiB memory.