### PR TITLE
cosmic-session: add variable for dconf profile location

### DIFF
--- a/pkgs/cosmic-session/package.nix
+++ b/pkgs/cosmic-session/package.nix
@@ -51,6 +51,9 @@ rustPlatform.buildRustPackage {
     "--set"
     "prefix"
     (placeholder "out")
+    "--set"
+    "cosmic_dconf_profile"
+    "cosmic"
   ];
 
   env.XDP_COSMIC = lib.getExe xdg-desktop-portal-cosmic;


### PR DESCRIPTION
Fixes #517 by setting correct dconf profile location.