### PR TITLE
Faster x86 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,29 @@ jobs:
   build:
     strategy:
       matrix:
+#        architecture:
+#          - system: x86_64-linux
+#            runner: [linux, x64, ktisis, ktisis-c3d-highmem-8, ktisis-30GB]
+#          - system: aarch64-linux
+#            runner: [linux, ARM64, ktisis, ktisis-c4a-highmem-8, ktisis-30GB]
+#        attribute:
+#          - vm.closure
+#          - vm-stable.closure
         architecture:
           - system: x86_64-linux
-            runner: [linux, x64, ktisis, ktisis-c3d-highmem-4, ktisis-30GB]
+            runner: [linux, x64, ktisis, ktisis-c3d-highmem-8, ktisis-30GB]
+            attribute: vm.closure
+          - system: x86_64-linux
+            runner: [ linux, x64, ktisis, ktisis-n4-highmem-8, ktisis-30GB ]
+            attribute: vm-stable.closure
           - system: aarch64-linux
             runner: [linux, ARM64, ktisis, ktisis-c4a-highmem-4, ktisis-30GB]
-        attribute:
-          - vm.closure
-          - vm-stable.closure
+            attribute: vm.closure
+          - system: aarch64-linux
+            runner: [ linux, ARM64, ktisis, ktisis-c4a-highmem-4, ktisis-30GB ]
+            attribute: vm-stable.closure
 
-    name: Build - ${{ matrix.architecture.system }} - ${{ matrix.attribute }}
+    name: Build - ${{ matrix.architecture.system }} - ${{ matrix.architecture.attribute }}
     runs-on: ${{ matrix.architecture.runner }}
 
     steps:
@@ -35,6 +48,6 @@ jobs:
 
       - env:
           SYSTEM: ${{ matrix.architecture.system }}
-          ATTRIBUTE: ${{ matrix.attribute }}
+          ATTRIBUTE: ${{ matrix.architecture.attribute }}
         run: |
           nix -vL build --show-trace --cores 4 --max-jobs 1 --system "$SYSTEM" ".#$ATTRIBUTE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         architecture:
           - system: x86_64-linux
-            runner: [linux, x64, ktisis, ktisis-n4-highmem-4, ktisis-30GB]
+            runner: [linux, x64, ktisis, ktisis-c3d-highmem-4, ktisis-30GB]
           - system: aarch64-linux
             runner: [linux, ARM64, ktisis, ktisis-c4a-highmem-4, ktisis-30GB]
         attribute:


### PR DESCRIPTION
The current CPU limit we have is per machine family, so as a workaround we can have Stable and Unstable use different machine families so that we can allocate each one more CPU's.

Not possible with ARM due to there only being one viable machine family (I don't know how long COSMIC would take to build on an Ampere Altra and I don't want to find out).

This is temporarily until the CPU limit can be raised to something more reasonable.