### PR TITLE
Stop over-using `with lib;`

### DIFF
--- a/pkgs/chronos/package.nix
+++ b/pkgs/chronos/package.nix
@@ -41,14 +41,14 @@ rustPlatform.buildRustPackage {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/cosmic-utils/chronos";
     description = "Simple Pomodoro timer built using libcosmic";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "chronos";
   };
 }

--- a/pkgs/cosmic-applets/package.nix
+++ b/pkgs/cosmic-applets/package.nix
@@ -68,13 +68,13 @@ rustPlatform.buildRustPackage {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-applets";
     description = "Applets for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/cosmic-applibrary/package.nix
+++ b/pkgs/cosmic-applibrary/package.nix
@@ -69,14 +69,14 @@ rustPlatform.buildRustPackage {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-applibrary";
     description = "Application Template for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-app-library";
   };
 }

--- a/pkgs/cosmic-bg/package.nix
+++ b/pkgs/cosmic-bg/package.nix
@@ -48,14 +48,14 @@ rustPlatform.buildRustPackage {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-bg";
     description = "Applies Background for the COSMIC Desktop Environment";
-    license = licenses.mpl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-bg";
   };
 }

--- a/pkgs/cosmic-comp/package.nix
+++ b/pkgs/cosmic-comp/package.nix
@@ -74,14 +74,14 @@ rustPlatform.buildRustPackage {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-comp";
     description = "Compositor for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-comp";
   };
 }

--- a/pkgs/cosmic-edit/package.nix
+++ b/pkgs/cosmic-edit/package.nix
@@ -62,14 +62,14 @@ rustPlatform.buildRustPackage rec {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-edit";
     description = "Text Editor for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-edit";
   };
 }

--- a/pkgs/cosmic-ext-applet-clipboard-manager/package.nix
+++ b/pkgs/cosmic-ext-applet-clipboard-manager/package.nix
@@ -48,14 +48,14 @@ rustPlatform.buildRustPackage {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/cosmic-utils/clipboard-manager";
     description = "Clipboard manager for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-ext-applet-clipboard-manager";
   };
 }

--- a/pkgs/cosmic-ext-applet-emoji-selector/package.nix
+++ b/pkgs/cosmic-ext-applet-emoji-selector/package.nix
@@ -51,17 +51,17 @@ rustPlatform.buildRustPackage {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/leb-kuchen/cosmic-ext-applet-emoji-selector";
     description = "Emoji selector applet for the COSMIC Desktop Environment";
-    license = with licenses; [
+    license = with lib.licenses; [
       mpl20
       mit
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-ext-applet-emoji-selector";
   };
 }

--- a/pkgs/cosmic-ext-applet-external-monitor-brightness/package.nix
+++ b/pkgs/cosmic-ext-applet-external-monitor-brightness/package.nix
@@ -49,16 +49,16 @@ rustPlatform.buildRustPackage {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/maciekk64/cosmic-ext-applet-external-monitor-brightness";
     description = "Change brightness of external monitors via DDC/CI protocol. You can also quickly toggle COSMIC system dark mode.";
-    license = with licenses; [
+    license = with lib.licenses; [
       gpl3Only
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-ext-applet-external-monitor-brightness";
   };
 }

--- a/pkgs/cosmic-ext-calculator/package.nix
+++ b/pkgs/cosmic-ext-calculator/package.nix
@@ -41,14 +41,14 @@ rustPlatform.buildRustPackage {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/cosmic-utils/calculator";
     description = "Calculator for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-ext-calculator";
   };
 }

--- a/pkgs/cosmic-ext-ctl/package.nix
+++ b/pkgs/cosmic-ext-ctl/package.nix
@@ -21,14 +21,14 @@ rustPlatform.buildRustPackage {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "CLI for COSMIC Desktop Environment configuration management";
     homepage = "https://github.com/cosmic-utils/cosmic-ctl";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-ctl";
   };
 }

--- a/pkgs/cosmic-ext-examine/package.nix
+++ b/pkgs/cosmic-ext-examine/package.nix
@@ -56,14 +56,14 @@ rustPlatform.buildRustPackage rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/cosmic-utils/examine";
     description = "System information viewer for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "examine";
   };
 }

--- a/pkgs/cosmic-ext-forecast/package.nix
+++ b/pkgs/cosmic-ext-forecast/package.nix
@@ -50,14 +50,14 @@ rustPlatform.buildRustPackage rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/cosmic-utils/forecast";
     description = "Weather forecast for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-ext-forecast";
   };
 }

--- a/pkgs/cosmic-ext-observatory/package.nix
+++ b/pkgs/cosmic-ext-observatory/package.nix
@@ -86,14 +86,14 @@ rustPlatform.buildRustPackage {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/cosmic-utils/observatory";
     description = "System monitor application for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "observatory";
   };
 }

--- a/pkgs/cosmic-ext-tasks/package.nix
+++ b/pkgs/cosmic-ext-tasks/package.nix
@@ -52,14 +52,14 @@ rustPlatform.buildRustPackage rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/cosmic-utils/tasks";
     description = "Simple task management application for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "tasks";
   };
 }

--- a/pkgs/cosmic-ext-tweaks/package.nix
+++ b/pkgs/cosmic-ext-tweaks/package.nix
@@ -50,14 +50,14 @@ rustPlatform.buildRustPackage rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/cosmic-utils/tweaks";
     description = "Tweaking tool for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-ext-tweaks";
   };
 }

--- a/pkgs/cosmic-files/package.nix
+++ b/pkgs/cosmic-files/package.nix
@@ -66,14 +66,14 @@ rustPlatform.buildRustPackage rec {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-files";
     description = "File Manager for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-files";
   };
 }

--- a/pkgs/cosmic-greeter/package.nix
+++ b/pkgs/cosmic-greeter/package.nix
@@ -73,14 +73,14 @@ rustPlatform.buildRustPackage {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-greeter";
     description = "Greeter for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-greeter";
   };
 }

--- a/pkgs/cosmic-icons/package.nix
+++ b/pkgs/cosmic-icons/package.nix
@@ -41,13 +41,13 @@ stdenvNoCC.mkDerivation {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     description = "System76 COSMIC icon theme for Linux";
     homepage = "https://github.com/pop-os/cosmic-icons";
-    license = with licenses; [ cc-by-sa-40 ];
-    maintainers = with maintainers; [
+    license = with lib.licenses; [ cc-by-sa-40 ];
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/cosmic-idle/package.nix
+++ b/pkgs/cosmic-idle/package.nix
@@ -51,14 +51,14 @@ rustPlatform.buildRustPackage {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-idle";
     description = "Idle daemon for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-idle";
   };
 }

--- a/pkgs/cosmic-launcher/package.nix
+++ b/pkgs/cosmic-launcher/package.nix
@@ -48,14 +48,14 @@ rustPlatform.buildRustPackage {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-launcher";
     description = "Launcher for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-launcher";
   };
 }

--- a/pkgs/cosmic-notifications/package.nix
+++ b/pkgs/cosmic-notifications/package.nix
@@ -48,14 +48,14 @@ rustPlatform.buildRustPackage {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-notifications";
     description = "Notifications for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-notifications";
   };
 }

--- a/pkgs/cosmic-osd/package.nix
+++ b/pkgs/cosmic-osd/package.nix
@@ -41,14 +41,14 @@ rustPlatform.buildRustPackage {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-osd";
     description = "OSD for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib. platforms.linux;
     mainProgram = "cosmic-osd";
   };
 }

--- a/pkgs/cosmic-panel/package.nix
+++ b/pkgs/cosmic-panel/package.nix
@@ -48,14 +48,14 @@ rustPlatform.buildRustPackage {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-panel";
     description = "Panel for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-panel";
   };
 }

--- a/pkgs/cosmic-player/package.nix
+++ b/pkgs/cosmic-player/package.nix
@@ -64,14 +64,14 @@ rustPlatform.buildRustPackage {
     extraArgs = [ "--version-regex" "epoch-(.*)" ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-player";
     description = "Media player for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-player";
   };
 }

--- a/pkgs/cosmic-protocols/package.nix
+++ b/pkgs/cosmic-protocols/package.nix
@@ -25,16 +25,16 @@ stdenv.mkDerivation {
     #extraArgs = [ "--version-regex" "epoch-(.*)" ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-protocols";
-    description = "Addtional wayland-protocols used by the COSMIC Desktop Environment";
-    license = [
-      licenses.mit
-      licenses.gpl3Only
+    description = "Additional wayland-protocols used by the COSMIC Desktop Environment";
+    license = with lib.licenses; [
+      mit
+      gpl3Only
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/cosmic-randr/package.nix
+++ b/pkgs/cosmic-randr/package.nix
@@ -48,14 +48,14 @@ rustPlatform.buildRustPackage {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-randr";
     description = "Library and utility for displaying and configuring Wayland outputs";
-    license = licenses.mpl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-randr";
   };
 }

--- a/pkgs/cosmic-reader/package.nix
+++ b/pkgs/cosmic-reader/package.nix
@@ -29,14 +29,14 @@ rustPlatform.buildRustPackage {
     #extraArgs = [ "--version-regex" "epoch-(.*)" ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-reader";
     description = "PDF reader for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-reader";
   };
 }

--- a/pkgs/cosmic-screenshot/package.nix
+++ b/pkgs/cosmic-screenshot/package.nix
@@ -41,14 +41,14 @@ rustPlatform.buildRustPackage {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-screenshot";
     description = "Screenshot tool for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-screenshot";
   };
 }

--- a/pkgs/cosmic-session/package.nix
+++ b/pkgs/cosmic-session/package.nix
@@ -67,14 +67,14 @@ rustPlatform.buildRustPackage {
     providedSessions = [ "cosmic" ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-session";
     description = "Session manager for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
+    license = lib.licenses.gpl3Only;
     mainProgram = "cosmic-session";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/cosmic-settings-daemon/package.nix
+++ b/pkgs/cosmic-settings-daemon/package.nix
@@ -44,14 +44,14 @@ rustPlatform.buildRustPackage {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-settings-daemon";
     description = "Settings daemon for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-settings-daemon";
   };
 }

--- a/pkgs/cosmic-settings/package.nix
+++ b/pkgs/cosmic-settings/package.nix
@@ -83,14 +83,14 @@ rustPlatform.buildRustPackage {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-settings";
     description = "Settings for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-settings";
   };
 }

--- a/pkgs/cosmic-store/package.nix
+++ b/pkgs/cosmic-store/package.nix
@@ -58,14 +58,14 @@ rustPlatform.buildRustPackage rec {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-store";
     description = "App Store for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-store";
   };
 }

--- a/pkgs/cosmic-term/package.nix
+++ b/pkgs/cosmic-term/package.nix
@@ -59,14 +59,14 @@ rustPlatform.buildRustPackage rec {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-term";
     description = "Terminal for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-term";
   };
 }

--- a/pkgs/cosmic-wallpapers/package.nix
+++ b/pkgs/cosmic-wallpapers/package.nix
@@ -27,16 +27,16 @@ stdenvNoCC.mkDerivation {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     description = "Wallpapers for the COSMIC Desktop Environment";
     homepage = "https://github.com/pop-os/cosmic-wallpapers";
-    license = with licenses; [
+    license = with lib.licenses; [
       cc-by-40
       publicDomain
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/cosmic-workspaces-epoch/package.nix
+++ b/pkgs/cosmic-workspaces-epoch/package.nix
@@ -48,14 +48,14 @@ rustPlatform.buildRustPackage {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/cosmic-workspaces-epoch";
     description = "Workspaces Epoch for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "cosmic-workspaces";
   };
 }

--- a/pkgs/libcosmicAppHook/package.nix
+++ b/pkgs/libcosmicAppHook/package.nix
@@ -67,8 +67,8 @@ makeSetupHook {
 
   meta = {
     description = "Setup hook for configuring and wrapping applications based on libcosmic";
-    maintainers = [
-      # lib.maintainers.lilyinstarlight
+    maintainers = with lib.maintainers; [
+      # lilyinstarlight
     ];
   };
 } ./libcosmic-app-hook.sh

--- a/pkgs/pop-launcher/package.nix
+++ b/pkgs/pop-launcher/package.nix
@@ -78,14 +78,14 @@ rustPlatform.buildRustPackage {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Modular IPC-based desktop launcher service";
     homepage = "https://github.com/pop-os/launcher";
-    license = licenses.mpl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "pop-launcher";
   };
 }

--- a/pkgs/quick-webapps/package.nix
+++ b/pkgs/quick-webapps/package.nix
@@ -48,14 +48,14 @@ rustPlatform.buildRustPackage {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/cosmic-utils/web-apps";
     description = "Web app manager for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "quick-webapps";
   };
 }

--- a/pkgs/stellarshot/package.nix
+++ b/pkgs/stellarshot/package.nix
@@ -46,14 +46,14 @@ rustPlatform.buildRustPackage rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/cosmic-utils/stellarshot";
     description = "Simple backup application using Rustic for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "stellarshot";
   };
 }

--- a/pkgs/xdg-desktop-portal-cosmic/package.nix
+++ b/pkgs/xdg-desktop-portal-cosmic/package.nix
@@ -62,14 +62,14 @@ rustPlatform.buildRustPackage rec {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pop-os/xdg-desktop-portal-cosmic";
     description = "XDG Desktop Portal for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
       # lilyinstarlight
     ];
     mainProgram = "xdg-desktop-portal-cosmic";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
It follow this suggestion https://github.com/NixOS/nixpkgs/issues/208242 .
We are currently moving away from using `with lib;` for meta in nixpkgs repo, and this change is in line with that.