### PR TITLE
Revert changes to stable/unstable CI VM's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 #          - vm-stable.closure
         architecture:
           - system: x86_64-linux
-            runner: [linux, X64, ktisis, ktisis-n4-highmem-8, ktisis-30GB]
+            runner: [linux, X64, ktisis, ktisis-c3d-highmem-8, ktisis-30GB]
             attribute: vm.closure
           - system: x86_64-linux
             runner: [linux, X64, ktisis, ktisis-n4-highmem-8, ktisis-30GB]


### PR DESCRIPTION
Issues with self-hosted runner registration are still being looked into, but VM type doesn't seem to be the cause. This also prevents builds being held up on waiting for the VM type to be available.