### PR TITLE
treewide: remove unnecessary vergen env variables

### DIFF
--- a/pkgs/cosmic-ext-tweaks/package.nix
+++ b/pkgs/cosmic-ext-tweaks/package.nix
@@ -10,7 +10,7 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "cosmic-ext-tweaks";
   version = "0.1.3-unstable-2025-01-22";
 
@@ -45,8 +45,6 @@ rustPlatform.buildRustPackage rec {
     "bin-src"
     "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-ext-tweaks"
   ];
-
-  env.VERGEN_GIT_SHA = src.rev;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/cosmic-store/package.nix
+++ b/pkgs/cosmic-store/package.nix
@@ -12,7 +12,7 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "cosmic-store";
   version = "1.0.0-alpha.5.1-unstable-2025-02-11";
 
@@ -48,8 +48,6 @@ rustPlatform.buildRustPackage rec {
     "bin-src"
     "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-store"
   ];
-
-  env.VERGEN_GIT_SHA = src.rev;
 
   passthru.updateScript = nix-update-script {
     extraArgs = [

--- a/pkgs/examine/package.nix
+++ b/pkgs/examine/package.nix
@@ -11,7 +11,7 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "examine";
   version = "1.0.0-unstable-2025-01-26";
 
@@ -41,8 +41,6 @@ rustPlatform.buildRustPackage rec {
     "bin-src"
     "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/examine"
   ];
-
-  env.VERGEN_GIT_SHA = src.rev;
 
   postInstall = ''
     libcosmicAppWrapperArgs+=(--prefix PATH : ${

--- a/pkgs/forecast/package.nix
+++ b/pkgs/forecast/package.nix
@@ -10,7 +10,7 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "forecast";
   version = "0-unstable-2025-02-12";
 
@@ -45,8 +45,6 @@ rustPlatform.buildRustPackage rec {
     "bin-src"
     "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-ext-forecast"
   ];
-
-  env.VERGEN_GIT_SHA = src.rev;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/stellarshot/package.nix
+++ b/pkgs/stellarshot/package.nix
@@ -8,7 +8,7 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "stellarshot";
   version = "0-unstable-2025-01-14";
 
@@ -41,8 +41,6 @@ rustPlatform.buildRustPackage rec {
 
   # TODO: upstream depends on inter-test side effects and therefore depends on test ordering and lack of concurrency, but tests also do not seem useful
   doCheck = false;
-
-  env.VERGEN_GIT_SHA = src.rev;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/tasks/package.nix
+++ b/pkgs/tasks/package.nix
@@ -11,7 +11,7 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "tasks";
   version = "0.1.1-unstable-2025-01-19";
 
@@ -47,8 +47,6 @@ rustPlatform.buildRustPackage rec {
     "bin-src"
     "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/tasks"
   ];
-
-  env.VERGEN_GIT_SHA = src.rev;
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
These environment variables were not necessary anymore, since vergen is not being used anymore in the About page of these applications.

Eventually the vergen hook could also be dropped from libcosmicAppHook, after all cosmic applications are updated to an updated version of libcosmic