### PR TITLE
Use the same VM shape for all x86 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             runner: [linux, X64, ktisis, ktisis-c3d-highmem-8, ktisis-30GB]
             attribute: vm.closure
           - system: x86_64-linux
-            runner: [linux, X64, ktisis, ktisis-n4-highmem-8, ktisis-30GB]
+            runner: [linux, X64, ktisis, ktisis-c3d-highmem-8, ktisis-30GB]
             attribute: vm-stable.closure
           - system: aarch64-linux
             runner: [linux, ARM64, ktisis, ktisis-c4a-highmem-4, ktisis-30GB]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,29 +12,16 @@ jobs:
   build:
     strategy:
       matrix:
-#        architecture:
-#          - system: x86_64-linux
-#            runner: [linux, x64, ktisis, ktisis-c3d-highmem-8, ktisis-30GB]
-#          - system: aarch64-linux
-#            runner: [linux, ARM64, ktisis, ktisis-c4a-highmem-8, ktisis-30GB]
-#        attribute:
-#          - vm.closure
-#          - vm-stable.closure
         architecture:
           - system: x86_64-linux
-            runner: [linux, X64, ktisis, ktisis-c3d-highmem-8, ktisis-30GB]
-            attribute: vm.closure
-          - system: x86_64-linux
-            runner: [linux, X64, ktisis, ktisis-c3d-highmem-8, ktisis-30GB]
-            attribute: vm-stable.closure
+            runner: [linux, x64, ktisis, ktisis-c3d-highmem-8, ktisis-30GB]
           - system: aarch64-linux
             runner: [linux, ARM64, ktisis, ktisis-c4a-highmem-4, ktisis-30GB]
-            attribute: vm.closure
-          - system: aarch64-linux
-            runner: [linux, ARM64, ktisis, ktisis-c4a-highmem-4, ktisis-30GB]
-            attribute: vm-stable.closure
+        attribute:
+          - vm.closure
+          - vm-stable.closure
 
-    name: Build - ${{ matrix.architecture.system }} - ${{ matrix.architecture.attribute }}
+    name: Build - ${{ matrix.architecture.system }} - ${{ matrix.attribute }}
     runs-on: ${{ matrix.architecture.runner }}
 
     steps:
@@ -52,14 +39,14 @@ jobs:
 
       - env:
           SYSTEM: ${{ matrix.architecture.system }}
-          ATTRIBUTE: ${{ matrix.architecture.attribute }}
+          ATTRIBUTE: ${{ matrix.attribute }}
         run: |
           nix -L build --show-trace --cores 0 --max-jobs 1 --system "$SYSTEM" ".#$ATTRIBUTE"
 
       - name: Pin store path in Cachix
         env:
           SYSTEM: ${{ matrix.architecture.system }}
-          ATTRIBUTE: ${{ matrix.architecture.attribute }}
+          ATTRIBUTE: ${{ matrix.attribute }}
         run: |
           storepath="$(nix eval --raw --system "$SYSTEM" ".#$ATTRIBUTE")"
           cachix push cosmic "$storepath"


### PR DESCRIPTION
My request for additional CPU quota was approved for x86, so we can now use the same shape for x86 builds.

Unfortunately the same request was rejected for ARM, ~~so the ugly hack has to stay for now~~.