### PR TITLE
treewide: remove redundant `pkg-config` in nativeBuildInputs

### DIFF
--- a/pkgs/cosmic-applets/package.nix
+++ b/pkgs/cosmic-applets/package.nix
@@ -7,7 +7,6 @@
   glib,
   just,
   libinput,
-  pkg-config,
   pulseaudio,
   stdenv,
   udev,
@@ -33,9 +32,9 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [
     libcosmicAppHook
     just
-    pkg-config
     util-linux
   ];
+
   buildInputs = [
     dbus
     glib

--- a/pkgs/cosmic-comp/package.nix
+++ b/pkgs/cosmic-comp/package.nix
@@ -8,7 +8,6 @@
   libinput,
   mesa,
   pixman,
-  pkg-config,
   seatd,
   stdenv,
   udev,
@@ -35,10 +34,8 @@ rustPlatform.buildRustPackage {
 
   separateDebugInfo = true;
 
-  nativeBuildInputs = [
-    libcosmicAppHook
-    pkg-config
-  ];
+  nativeBuildInputs = [ libcosmicAppHook ];
+
   buildInputs = [
     libdisplay-info
     (if libgbm != null then libgbm else mesa)

--- a/pkgs/cosmic-edit/package.nix
+++ b/pkgs/cosmic-edit/package.nix
@@ -9,7 +9,6 @@
   gtk3,
   just,
   libinput,
-  pkg-config,
   stdenv,
   nix-update-script,
 }:
@@ -31,8 +30,8 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     libcosmicAppHook
     just
-    pkg-config
   ];
+
   buildInputs = [
     glib
     gtk3

--- a/pkgs/cosmic-ext-applet-external-monitor-brightness/package.nix
+++ b/pkgs/cosmic-ext-applet-external-monitor-brightness/package.nix
@@ -6,7 +6,6 @@
   just,
   stdenv,
   nix-update-script,
-  pkg-config,
   udev,
 }:
 
@@ -27,7 +26,6 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [
     libcosmicAppHook
     just
-    pkg-config
   ];
 
   buildInputs = [

--- a/pkgs/cosmic-ext-tweaks/package.nix
+++ b/pkgs/cosmic-ext-tweaks/package.nix
@@ -5,7 +5,6 @@
   rustPlatform,
   just,
   openssl,
-  pkg-config,
   stdenv,
   nix-update-script,
 }:
@@ -27,7 +26,6 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [
     libcosmicAppHook
     just
-    pkg-config
   ];
 
   buildInputs = [

--- a/pkgs/cosmic-osd/package.nix
+++ b/pkgs/cosmic-osd/package.nix
@@ -3,7 +3,6 @@
   fetchFromGitHub,
   rustPlatform,
   libcosmicAppHook,
-  pkg-config,
   pulseaudio,
   udev,
   nix-update-script,
@@ -23,10 +22,8 @@ rustPlatform.buildRustPackage {
   useFetchCargoVendor = true;
   cargoHash = "sha256-vYehF2RjPrTZiuGcRUe4XX3ftRo7f+SIoKizD/kOtR8=";
 
-  nativeBuildInputs = [
-    libcosmicAppHook
-    pkg-config
-  ];
+  nativeBuildInputs = [ libcosmicAppHook ];
+
   buildInputs = [
     pulseaudio
     udev

--- a/pkgs/cosmic-player/package.nix
+++ b/pkgs/cosmic-player/package.nix
@@ -8,7 +8,6 @@
   glib,
   gst_all_1,
   just,
-  pkg-config,
   stdenv,
   nix-update-script,
 }:
@@ -31,7 +30,6 @@ rustPlatform.buildRustPackage {
     libcosmicAppHook
     rustPlatform.bindgenHook
     just
-    pkg-config
   ];
 
   buildInputs = [

--- a/pkgs/cosmic-settings/package.nix
+++ b/pkgs/cosmic-settings/package.nix
@@ -12,7 +12,6 @@
   just,
   libinput,
   pipewire,
-  pkg-config,
   pulseaudio,
   udev,
   util-linux,
@@ -45,9 +44,9 @@ rustPlatform.buildRustPackage {
     rustPlatform.bindgenHook
     cmake
     just
-    pkg-config
     util-linux
   ];
+
   buildInputs = [
     expat
     fontconfig

--- a/pkgs/cosmic-store/package.nix
+++ b/pkgs/cosmic-store/package.nix
@@ -7,7 +7,6 @@
   glib,
   just,
   openssl,
-  pkg-config,
   stdenv,
   nix-update-script,
 }:
@@ -29,8 +28,8 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [
     libcosmicAppHook
     just
-    pkg-config
   ];
+
   buildInputs = [
     glib
     flatpak

--- a/pkgs/cosmic-term/package.nix
+++ b/pkgs/cosmic-term/package.nix
@@ -6,7 +6,6 @@
   freetype,
   just,
   libinput,
-  pkg-config,
   rustPlatform,
   stdenv,
   nix-update-script,
@@ -29,7 +28,6 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     libcosmicAppHook
     just
-    pkg-config
   ];
 
   buildInputs = [

--- a/pkgs/cosmic-workspaces-epoch/package.nix
+++ b/pkgs/cosmic-workspaces-epoch/package.nix
@@ -3,7 +3,6 @@
   rustPlatform,
   fetchFromGitHub,
   libcosmicAppHook,
-  pkg-config,
   libgbm ? null,
   libinput,
   mesa,
@@ -25,10 +24,8 @@ rustPlatform.buildRustPackage {
   useFetchCargoVendor = true;
   cargoHash = "sha256-l5y9bOG/h24EfiAFfVKjtzYCzjxU2TI8wh6HBUwoVcE=";
 
-  nativeBuildInputs = [
-    libcosmicAppHook
-    pkg-config
-  ];
+  nativeBuildInputs = [ libcosmicAppHook ];
+
   buildInputs = [
     (if libgbm != null then libgbm else mesa)
     libinput

--- a/pkgs/forecast/package.nix
+++ b/pkgs/forecast/package.nix
@@ -5,7 +5,6 @@
   rustPlatform,
   just,
   openssl,
-  pkg-config,
   stdenv,
   nix-update-script,
 }:
@@ -27,7 +26,6 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [
     libcosmicAppHook
     just
-    pkg-config
   ];
 
   buildInputs = [

--- a/pkgs/quick-webapps/package.nix
+++ b/pkgs/quick-webapps/package.nix
@@ -5,7 +5,6 @@
   rustPlatform,
   just,
   openssl,
-  pkg-config,
   stdenv,
   nix-update-script,
 }:
@@ -27,7 +26,6 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     libcosmicAppHook
     just
-    pkg-config
   ];
 
   buildInputs = [

--- a/pkgs/xdg-desktop-portal-cosmic/package.nix
+++ b/pkgs/xdg-desktop-portal-cosmic/package.nix
@@ -7,7 +7,6 @@
   libgbm ? null,
   mesa,
   pipewire,
-  pkg-config,
   gst_all_1,
   nix-update-script,
 }:
@@ -31,8 +30,8 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     libcosmicAppHook
     rustPlatform.bindgenHook
-    pkg-config
   ];
+
   buildInputs = [
     (if libgbm != null then libgbm else mesa)
     pipewire


### PR DESCRIPTION
It is already propagated by libcosmicAppHook, so it is redundant to add them explicitly in nativeBuildInputs