### PR TITLE
libcosmicAppHook: prefer `stdenv.hostPlatform.isDarwin`

### DIFF
--- a/pkgs/libcosmicAppHook/package.nix
+++ b/pkgs/libcosmicAppHook/package.nix
@@ -32,7 +32,7 @@ makeSetupHook {
       xorg.libXi
       xorg.libxcb
     ]
-    ++ lib.optionals (!stdenv.isDarwin) [
+    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
       wayland
       vulkan-loader
     ];
@@ -58,7 +58,7 @@ makeSetupHook {
         # for x11rb
         "xcb"
       ]
-      ++ lib.optionals (!stdenv.isDarwin) [
+      ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
         # for wgpu-hal, wayland-sys
         "wayland-client"
         # for wgpu-hal


### PR DESCRIPTION
Doing the same I did in NixOS/nixpkgs#385120, as `stdenv.isDarwin` could cause issues