### PR TITLE
cosmic-files: re-enable checks

### DIFF
--- a/pkgs/cosmic-files/package.nix
+++ b/pkgs/cosmic-files/package.nix
@@ -37,18 +37,15 @@ rustPlatform.buildRustPackage rec {
   #  "--package"
   #  "cosmic-files-applet"
   #];
-  #cargoTestFlags = [
+  # cargoTestFlags = [
   #  "--package"
   #  "cosmic-files"
   #  "--package"
   #  "cosmic-files-applet"
-  #];
+  # ];
 
   dontUseJustBuild = true;
   dontUseJustCheck = true;
-
-  # TODO: remove when upstream fixes checks again
-  doCheck = false;
 
   justFlags = [
     "--set"


### PR DESCRIPTION
Checks are not failing anymore. Using regular `cargoTestFlags`  because it shouldn't really matter like it does for the `buildPhase`