### PR TITLE
Re-enable the Rust overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,7 +52,28 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs-stable": "nixpkgs-stable",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742437918,
+        "narHash": "sha256-Vflb6KJVDikFcM9E231mRN88uk4+jo7BWtaaQMifthI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "f03085549609e49c7bcbbee86a1949057d087199",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },


### PR DESCRIPTION
Required due to COSMIC now requiring Rust 1.84 at the minimum and NixOS 24.11 packaging Rust 1.83.

This is effectively a revert of c91f1104f886f9b3211fca2570931c50f69443f4 but also bumps the minimum required Rust version to 1.84, so this should only apply to NixOS 24.11 builds and not Unstable.