### PR TITLE
nixos/cosmic-greeter: add package option

### DIFF
--- a/nixos/cosmic-greeter/module.nix
+++ b/nixos/cosmic-greeter/module.nix
@@ -15,6 +15,7 @@ in
 
   options.services.displayManager.cosmic-greeter = {
     enable = lib.mkEnableOption "COSMIC greeter";
+    package = lib.mkPackageOption pkgs "cosmic-greeter" { };
   };
 
   config = lib.mkIf cfg.enable {
@@ -24,7 +25,7 @@ in
       settings = {
         default_session = {
           user = "cosmic-greeter";
-          command = ''${lib.getExe' pkgs.coreutils "env"} XCURSOR_THEME="''${XCURSOR_THEME:-Pop}" systemd-cat -t cosmic-greeter ${lib.getExe pkgs.cosmic-comp} ${lib.getExe pkgs.cosmic-greeter}'';
+          command = ''${lib.getExe' pkgs.coreutils "env"} XCURSOR_THEME="''${XCURSOR_THEME:-Pop}" systemd-cat -t cosmic-greeter ${lib.getExe pkgs.cosmic-comp} ${lib.getExe cfg.package}'';
         };
       };
     };
@@ -36,7 +37,7 @@ in
       serviceConfig = {
         Type = "dbus";
         BusName = "com.system76.CosmicGreeter";
-        ExecStart = lib.getExe' pkgs.cosmic-greeter "cosmic-greeter-daemon";
+        ExecStart = lib.getExe' cfg.package "cosmic-greeter-daemon";
         Restart = "on-failure";
       };
     };
@@ -63,6 +64,6 @@ in
     security.pam.services.cosmic-greeter = { };
 
     # dbus definitions
-    services.dbus.packages = with pkgs; [ cosmic-greeter ];
+    services.dbus.packages = [ cfg.package ];
   };
 }

--- a/nixos/cosmic/module.nix
+++ b/nixos/cosmic/module.nix
@@ -60,7 +60,7 @@ in
         })
         cosmic-edit
         cosmic-files
-        cosmic-greeter
+        config.services.displayManager.cosmic-greeter.package
         cosmic-icons
         cosmic-idle
         cosmic-launcher


### PR DESCRIPTION
Adds a package option for cosmic-greeter, also updates cosmic module to use `services.displayManager.cosmic-greeter.package` for the cosmic-greeter package