### PR TITLE
build fixes for update_cosmic_action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+result
+result-*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-result
-result-*
+result*

--- a/pkgs/cosmic-files/package.nix
+++ b/pkgs/cosmic-files/package.nix
@@ -72,7 +72,8 @@ rustPlatform.buildRustPackage rec {
 
   checkPhase = ''
     baseCargoTestFlags="$cargoTestFlags"
-    cargoTestFlags="$baseCargoTestFlags --package cosmic-files"
+    # operation tests require io_uring and fail in nix-sandbox
+    cargoTestFlags="$baseCargoTestFlags --package cosmic-files -- --skip operation::tests"
     runHook cargoCheckHook
     cargoTestFlags="$baseCargoTestFlags --package cosmic-files-applet"
     runHook cargoCheckHook

--- a/pkgs/cosmic-session/package.nix
+++ b/pkgs/cosmic-session/package.nix
@@ -48,17 +48,12 @@ rustPlatform.buildRustPackage {
     "target/${stdenv.hostPlatform.rust.cargoShortTarget}"
     "--set"
     "cosmic_dconf_profile"
-    "cosmic"
+    "${placeholder "out"}/etc/dconf/profile/cosmic"
   ];
 
   env.XDP_COSMIC = lib.getExe xdg-desktop-portal-cosmic;
   # use `orca` from PATH (instead of absolute path) if available
   env.ORCA = "orca";
-
-  postInstall = ''
-    mkdir -p $out/etc
-    cp -r data/dconf $out/etc/
-  '';
 
   passthru = {
     updateScript = nix-update-script {


### PR DESCRIPTION
Unblocks #753 

Tests were broken in [this commit](https://github.com/pop-os/cosmic-files/commit/79aa8f887ab5942b48be60c6b515859af895d77d) because nix-sandbox blocks io_uring. 

I also added a .gitignore because I accidentally pushed the build artifact at first, so I think it makes sense to add.