### PR TITLE
{update; CI}: don't fail update script if single update failed, provide diagnostics to action logs

### DIFF
--- a/.github/workflows/cosmic.yml
+++ b/.github/workflows/cosmic.yml
@@ -30,7 +30,11 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - run: nix -vL run --show-trace .#update
+      - name: Build update script
+        run: nix -vL build --show-trace .#update
+
+      - name: Run update script
+        run: result/bin/cosmic-unstable-update
 
       - id: create-pr
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/cosmic.yml
+++ b/.github/workflows/cosmic.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Run update script
         run: result/bin/cosmic-unstable-update
 
+      - name: Clean git repository
+        run: |
+          git clean -fdx
+          git reset --hard HEAD
+
       - id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
Due to https://github.com/pop-os/cosmic-wallpapers/issues/8, the update script for `cosmic-wallpapers` fails, making entire update script fail. first commit fixes that.

Additionally, it provides warning diagnostics to github action when update failed.

To improve visibility of logs in the action, I split the build and running the script into separate steps.

Because failed update doesn't cleanup files, I added step to clean the git worktree before step that creates pr

---

Thank you for creating cosmic desktop modules for NixOS.